### PR TITLE
Update project eve logo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -281,7 +281,7 @@ landscape:
             homepage_url: 'https://wiki.lfedge.org/display/EVE/Project+EVE'
             project: growth
             repo_url: 'https://github.com/lf-edge/eve'
-            logo: logo-eve-wtext.svg
+            logo: 'https://github.com/lf-edge/artwork/blob/master/project-eve/icon/color/eve-icon-color.svg'
             crunchbase: 'https://www.crunchbase.com/organization/lf-edge'
       - subcategory:
         name: IAAS


### PR DESCRIPTION
EVE has change its logo to what was their icon.  This updates logo used in the landscape.